### PR TITLE
fix: ship cordis.patch.yml in the published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "client.js",
     "panel.html",
     "memes/",
-    "docs/"
+    "docs/",
+    "cordis.patch.yml"
   ],
   "exports": {
     ".": "./index.js",


### PR DESCRIPTION
## 问题与修复

`dsh web` 启动时直接崩溃：

```
Error: dsh: failed to read overlay .../dsh-expression/cordis.patch.yml:
ENOENT: no such file or directory
```

根因：`package.json` 的 `files` 白名单漏了 `cordis.patch.yml`，导致它没有进入 npm tarball。
已逐一核对 **0.1.0 / 0.1.1 / 0.1.2 三个已发布版本全部缺失**（`npm pack` 逐一验证过）。
而 `dsh.bundle.patch` 声明了 `./cordis.patch.yml`，DSH 加载该 bundle 时必须读取此文件，缺失即启动失败。

修复：`files` 数组增加 `"cordis.patch.yml"`，一行改动，不涉及任何运行时代码。
本分支已用 `npm pack --dry-run` 验证：tarball 内容清单已包含 `cordis.patch.yml`（312B）。

## 环境

- 系统：Linux
- Node.js：v26.7.0（npm 12.0.2）
- DeepSeek Harness：@deepseek-ai/dsh 0.1.0-rc.6
- 安装方式：npm 全局安装，systemd 用户服务运行

## 测试结果（本机实测）

- 从仓库 `main` 拉取缺失的 `cordis.patch.yml` 补进本地安装目录后，`dsh web` 启动恢复正常，不再崩溃；
- systemd 用户服务 `dsh.service` 稳定 `active`，重启循环消失；
- Web UI 页面 HTTP 200，浏览器 console 零错误零警告；
- 服务日志确认插件完整加载：`send_meme 已注册(Web通道)`，管理 API `/dsh-memes-api`、管理面板 `/memes-panel` 均注册成功；
- `/dsh-memes` 路由实测：图库内图片返回 `200 image/jpeg`，白名单外路径返回 `404`，目录穿越请求被 SPA fallback 拦截，无文件泄露。

## 请作者配合

合并后请发布一个新版本（如 0.1.3），并用 `npm pack --dry-run` 确认 tarball 内容。
已发布的旧版本无法补救，npm 上现有版本都会触发此崩溃。
建议后续在 `package.json` 增加 `pack:check` 脚本（`npm pack --dry-run`）防再犯——参考 `a-memorix-deepseek-harness` 的同类做法。

## 又编：好用的很喵（还有自家astr的表情包嘛原来）
