### PR TITLE
feat: 上传表情包支持 AI 自动识别打标签

### DIFF
--- a/client.js
+++ b/client.js
@@ -101,6 +101,7 @@ window.__ModuleLoader__.load({
       const [upCaption, setUpCaption] = React.useState('')
       const [upKeywords, setUpKeywords] = React.useState('')
       const [uploading, setUploading] = React.useState(false)
+      const [recognizing, setRecognizing] = React.useState(false)
       const [uploadOpen, setUploadOpen] = React.useState(false)
       const [memeRoot, setMemeRoot] = React.useState('')
       const [memeRootInput, setMemeRootInput] = React.useState('')
@@ -292,9 +293,34 @@ window.__ModuleLoader__.load({
         }
         setUpFile(file)
         setUpPreview(URL.createObjectURL(file))
+        // 换图后清掉上一张的识别结果,避免误存错标签
+        setUpTag('')
+        setUpCaption('')
+        setUpKeywords('')
         const reader = new FileReader()
         reader.onload = () => setUpData64(String(reader.result || '').split(',')[1] || '')
         reader.readAsDataURL(file)
+      }
+
+      // AI 识别:上传前先让模型看图,自动填分类/描述/关键词;失败不阻塞手动填写
+      const onRecognize = async () => {
+        if (!upFile) { setNotice('先选择图片'); return }
+        if (!upData64) { setNotice('图片还没读好,稍等片刻再试'); return }
+        setRecognizing(true)
+        try {
+          const res = await apiPost({ op: 'recognize', fileName: upFile.name, dataBase64: upData64 })
+          if (res && res.ok) {
+            setUpTag(res.tag || '')
+            setUpCaption(res.caption || '')
+            setUpKeywords(res.keywords || '')
+            setNotice('AI 已识别: [' + (res.tag || '?') + '] ' + (res.caption || ''))
+          } else {
+            setNotice('AI 识别失败: ' + (res && res.error || '未知错误'))
+          }
+        } catch (error) {
+          setNotice('AI 识别失败: ' + (error && error.message ? error.message : String(error)))
+        }
+        setRecognizing(false)
       }
 
       const onConfirmUpload = async () => {
@@ -492,6 +518,10 @@ window.__ModuleLoader__.load({
               h('label', null, upFile ? '已选: ' + upFile.name + ' (点击更换)' : '文件'),
               h('input', { type: 'text', placeholder: upFile ? '' : '先选图片', value: '', readOnly: true, style: { display: 'none' } }),
             ),
+            // AI 识别:选图后一键自动填分类/描述/关键词,识别失败不阻塞手动填写
+            upFile ? h('div', { className: 'row', style: { width: '100%' } },
+              h('button', { className: 'btn-primary', onClick: onRecognize, disabled: recognizing }, recognizing ? 'AI 识别中…' : 'AI 识别'),
+            ) : null,
             h('div', { className: 'field' },
               h('label', null, '分类(必填)'),
               h('div', { className: 'row', style: { width: '100%' } },

--- a/index.js
+++ b/index.js
@@ -531,7 +531,21 @@ export function apply(ctx, config) {
         }
         try {
           const op = String(body.op || '')
-          if (op === 'upload') {
+          if (op === 'recognize') {
+            // 上传弹窗的 AI 识别:只返回识别结果,不写入图库(用户确认后走 upload)
+            const fileName = String(body.fileName || '').trim()
+            const data = String(body.dataBase64 || '')
+            if (!data) throw new Error('缺少图片数据')
+            const buf = Buffer.from(data, 'base64')
+            if (buf.byteLength === 0 || buf.byteLength > 8 * 1024 * 1024) throw new Error('图片大小超限(≤8MB)')
+            const ext = fileName.includes('.') ? '.' + fileName.split('.').pop().toLowerCase() : ''
+            if (!IMAGE_EXTS.includes(ext)) throw new Error('仅支持 jpg/png/gif/webp')
+            const sel = ctx.agentDefaultModel && typeof ctx.agentDefaultModel.currentSelection === 'function'
+              ? ctx.agentDefaultModel.currentSelection() : null
+            const r = await recognizeImageBytes(ctx.get('llm'), sel, buf, MIME[ext.slice(1)] || 'image/jpeg', fileName)
+            if (!r.tag || !validTagRe.test(r.tag)) throw new Error('AI 未识别出有效分类,请手动选择')
+            json(res, { ok: true, tag: r.tag, caption: r.caption, keywords: r.keywords })
+          } else if (op === 'upload') {
             const tag = String(body.tag || '').trim().toLowerCase()
             const fileName = String(body.fileName || '').trim()
             const data = String(body.dataBase64 || '')


### PR DESCRIPTION
## 功能

喵喵喵，加了个 AI 自动打标签的策略，要不每回上传亲自打标签好麻烦。
设置面板「上传表情包」弹窗新增「AI 识别」按钮:选图后一键调用当前默认模型
识别图片内容,自动回填 分类(tag)/描述(caption)/关键词(keywords),
用户确认后上传。
<img width="582" height="932" alt="Screenshot from 2026-08-28 12-57-26" src="https://github.com/user-attachments/assets/1c926a00-7d8e-46df-a596-bd54273393a7" />

## 改动

- index.js (+15):/dsh-memes-api 新增 op=recognize,复用 learn_meme 的
  recognizeImageBytes 识图核心,只返回识别结果不写库
- client.js (+30):上传弹窗选图后显示 AI 识别按钮,识别结果自动回填表单;
  换图自动清空上次识别结果,避免误存错标签

## 设计说明

- 复用现有识图核心,不引入新依赖,不新增配置项
- 识别是「预填+可改」:用户上传前能看到识别结果,不满意可手动修改
- 识别失败(如模型不支持图片输入)只提示错误,不阻塞手动上传
- tag 沿用现有分类体系(六情绪桶+扩展标签),caption/keywords 自由文本

## 已知提示

识别使用当前默认模型,需要支持图片输入(vision 模型)。
若模型在 provider 配置中未声明 inputModalities 含 image,
识别会报「不支持图片输入」——需要在模型配置中声明。

关联 issue: #6