### PR TITLE
fix: reject zip entries escaping the pack directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@
  */
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync, rmSync } from 'node:fs'
-import { join, dirname, resolve } from 'node:path'
+import { join, dirname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { DatabaseSync } from 'node:sqlite'
 import {
@@ -577,16 +577,23 @@ export function apply(ctx, config) {
             const entries = unzipStore(Buffer.from(data, 'base64'))
             const indexPath = entries.get('index.db')
             if (!indexPath) throw new Error('ZIP 里没有 index.db,不是有效的表情包包')
-            // 解包到扫描目录/<name>(包外,持久)
-            const target = join(packsDirNow(), name)
-            rmSync(target, { recursive: true, force: true })
-            mkdirSync(target, { recursive: true })
+            // 解包到扫描目录/<name>(包外,持久)。先整体校验所有条目路径,
+            // 任何越界(绝对路径或 .. 逃逸)都拒绝导入,不落盘(历史教训:任意文件写)。
+            const targetAbs = resolve(join(packsDirNow(), name))
+            for (const [rel] of entries) {
+              const full = resolve(targetAbs, rel)
+              if (full !== targetAbs && !full.startsWith(targetAbs + sep)) {
+                throw new Error('ZIP 条目路径越界,已拒绝导入: ' + rel)
+              }
+            }
+            rmSync(targetAbs, { recursive: true, force: true })
+            mkdirSync(targetAbs, { recursive: true })
             for (const [rel, bytes] of entries) {
-              const full = join(target, rel)
+              const full = resolve(targetAbs, rel)
               mkdirSync(dirname(full), { recursive: true })
               writeFileSync(full, bytes)
             }
-            reloadMemeStore(target, name)
+            reloadMemeStore(targetAbs, name)
             json(res, { ok: true, ...packPayload(), total: memes.list().memes.length, message: '导入成功,已切换到新图库' })
           } else if (op === 'getMemeRoot') {
             json(res, { ok: true, ...packPayload() })


### PR DESCRIPTION
Fixes #9

## 问题

`importMemePack`（ZIP 图库导入）解包时对每个条目直接 `join(target, rel)` 写入，条目名含 `../` 时文件写到图库目录之外（任意文件写，可覆盖 DSH profile 的 `cordis.patch.yml` / `package.json`）。

## 改动

- 解包前先对全部条目做路径校验：`resolve(targetAbs, rel)` 必须位于 target 内（拒绝绝对路径与 `..` 逃逸），校验通过后才 `rmSync` + 落盘
- 守卫风格与 `memes.js` `resolveStored` 一致

## 验证

- 路径守卫行为测试 8/8 通过（合法条目放行；`../x.jpg`、`../../profiles/web/cordis.patch.yml`、`C:/Windows/win.ini`、`/etc/passwd` 均拒绝；`memes/../index.db` 规范化后仍在内部放行）
- `node --check index.js` 通过；顶层 import 冒烟通过（Node 24）

> 本 PR 由 dsh（DeepSeek Harness agent）辅助排查、修复并起草（与 #57 同源），发布前作者本人已审阅。
