### PR TITLE
fix: reject cross-origin state changes and cap request body on the meme api

### DIFF
--- a/index.js
+++ b/index.js
@@ -465,9 +465,17 @@ export function apply(ctx, config) {
       return { tag, caption, keywords }
     }
 
-    const readBody = (req) => new Promise((resolve, reject) => {
+    const readBody = (req, maxBytes = 32 * 1024 * 1024) => new Promise((resolve, reject) => {
       const chunks = []
-      req.on('data', (c) => chunks.push(c))
+      let total = 0
+      req.on('data', (c) => {
+        total += c.length
+        if (total > maxBytes) {
+          reject(new Error('请求体过大(>32MB)'))
+          return
+        }
+        chunks.push(c)
+      })
       req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
       req.on('error', reject)
     })
@@ -521,6 +529,20 @@ export function apply(ctx, config) {
             memes: rows.map((m) => urlFor(m, pid)),
           })
           return
+        }
+        // 状态变更请求:校验 Origin 与 Host 同源,防浏览器跨站触发(CSRF)。
+        // 缺失 Origin 的本地脚本/curl 请求放行(兼容),不同源一律 403。
+        const origin = req.headers.origin
+        if (origin) {
+          let sameOrigin = false
+          try {
+            const o = new URL(origin)
+            sameOrigin = o.host === String(req.headers.host || '')
+          } catch { sameOrigin = false }
+          if (!sameOrigin) {
+            json(res, { ok: false, error: '跨站请求被拒绝' }, 403)
+            return
+          }
         }
         let body
         try {


### PR DESCRIPTION
Fixes #10

## 问题

`/dsh-memes-api` 的状态变更端点（delete / deleteTag / upload / importMemePack / setPacksDir / setMemeRoot / setCompanionPrompt）无鉴权、无 Origin 校验：恶意网页可用 `no-cors` + `text/plain` POST 跨站触发（CSRF，可放大 #9 的任意文件写）。`readBody` 亦无大小上限。

## 改动

- 非 GET 请求校验 `Origin` 与请求 `Host` 同源，不同源返回 403；缺失 Origin 的本地脚本/curl 请求放行（兼容）
- `readBody` 增加 32 MB 上限，超限拒绝

## 验证

- Origin 校验行为测试 6/6 通过（同源放行、异源/坏 Origin 拒绝、无 Origin 放行）
- `node --check index.js` 通过

> 本 PR 由 dsh（DeepSeek Harness agent）辅助排查、修复并起草（与 #57 同源），发布前作者本人已审阅。
