### PR TITLE
fix: require node >= 22.13.0 for the node:sqlite builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ pnpm add file:/path/to/dsh-meme
 
 > 注意：pnpm 有「新包安全期」（默认 24h），刚发布的版本会被静默回落到旧版；急用可在 `pnpm-workspace.yaml` 的 `minimumReleaseAgeExclude` 里加上 `dsh-meme`。
 
+> 运行时要求：**Node ≥ 22.13.0**（依赖内置 `node:sqlite` 模块；22.5–22.12 需 `--experimental-sqlite` 标志，Node 20 不支持）。
+
 ## 配置
 
 默认内置两套图库：`official-001`（官方表情包 1 号，92 张）和 `dafeiyu-001`（大肥鱼，49 张），开箱用官方包，**无需任何配置**。

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.13.0"
   }
 }


### PR DESCRIPTION
Fixes #11

## 问题

`index.js` / `memes.js` 顶层 `import { DatabaseSync } from 'node:sqlite'` 需要 Node ≥ 22.13（22.5–22.12 需 `--experimental-sqlite`，Node 20 无此内置模块），而 `engines` 声明为 `>=20`，旧 Node 宿主在导入阶段直接 `ERR_UNKNOWN_BUILTIN_MODULE`。

## 改动

- `package.json` `engines.node` → `>=22.13.0`
- README 安装章节注明运行时要求

## 验证

- `node --check` 全部源文件通过；顶层 import 冒烟通过（Node 24，复用真实 `@deepseek-ai/dsh-tools`）

> 本 PR 由 dsh（DeepSeek Harness agent）辅助排查、修复并起草（与 #57 同源），发布前作者本人已审阅。
