### PR TITLE
perf: hoist makeMemeButton out of the slot render callback (stop per-render remount of the trigger button)

### DIFF
--- a/client.js
+++ b/client.js
@@ -1235,9 +1235,15 @@ window.__ModuleLoader__.load({
 
       // 输入框快捷发图(QQ 式)。
       const store = makeMemeStore()
+      // Hoisted out of the render callback on purpose: makeMemeButton() returns a fresh
+      // function component on every call, so creating it inside the slot render callback
+      // hands React a new component type on every re-render → the trigger button is
+      // unmounted and remounted each time (measured 20+ rebuilds/second while a turn is
+      // streaming), which in turn wakes every full-body MutationObserver in the host.
+      const MemeButton = makeMemeButton(store)
       slots.inject('conversation.input.left', () => slots.register(
         { name: 'conversation.input.left', id: 'meme-picker', order: 5, label: '表情包' },
-        (props) => React.createElement(makeMemeButton(store), { input: props.input }),
+        (props) => React.createElement(MemeButton, { input: props.input }),
       ))
       slots.inject('conversation.input.overlay', () => slots.register(
         { name: 'conversation.input.overlay', id: 'meme-picker', order: 5, label: '表情包' },


### PR DESCRIPTION
## What

Hoist `makeMemeButton(store)` out of the `conversation.input.left` slot render callback, so the trigger button component type is created once instead of on every render.

## Why

`makeMemeButton(store)` **returns a new function component on every call**:

```js
function makeMemeButton(store) {
  return function MemeButton(props) { ... }
}
```

Calling it inside the slot render callback therefore hands React a **different component type on every re-render**, so React unmounts the old node and mounts a new one each time.

Measured on dsh 0.1.5-rc.2 (Windows / Electron) with a CDP `MutationObserver` probe scoped to the conversation/input area:

```
+button.meme-trigger  /  --
+-  /  -button.meme-trigger
+button.meme-trigger  /  --
+-  /  -button.meme-trigger
...
```

median gap **0ms**, roughly **20+ rebuilds per second** while a turn is streaming.

## Impact

Every rebuild also wakes the full-body `MutationObserver`s installed by other plugins:

- `@linxin666/dsh-client-ui-skin-center` / `dsh-web-all` `syncHeight`: `getBoundingClientRect()` forced layout plus a `--dsh-composer-height` write on every body mutation;
- `dsh-web-all` `applyToTree`: whole-tree `querySelectorAll` + `setAttribute`.

Net effect on the host: the main thread saturates and finished content only lands in the DOM about **8 s after `turn/end`** (the desktop companion reports "done" well before the UI has painted the last of the reply).

## Fix

```js
const MemeButton = makeMemeButton(store)
slots.inject('conversation.input.left', () => slots.register(
  { name: 'conversation.input.left', id: 'meme-picker', order: 5, label: '表情包' },
  (props) => React.createElement(MemeButton, { input: props.input }),
))
```

## Verification

- `node --check client.js` passes.
- Same CDP probe after the change: **25 mutations / 6 s -> 0**; the `+/- button.meme-trigger` loop is gone.
- The button still works (picker opens, active state toggles).
- Running locally on dsh 0.1.5-rc.2 with no regressions observed so far.

The `conversation.input.overlay` registration already passes the existing `MemeBoard` component directly, so it is unaffected.

Refs #15
